### PR TITLE
Add 7tv/BTTV emote fetcher

### DIFF
--- a/TWThirdPartyEmoteManager.h
+++ b/TWThirdPartyEmoteManager.h
@@ -1,0 +1,12 @@
+#import <Foundation/Foundation.h>
+#import <UIKit/UIKit.h>
+
+@interface TWThirdPartyEmoteManager : NSObject
++ (instancetype)sharedManager;
+- (void)loadGlobalEmotes;
+- (void)loadChannelEmotesWithID:(NSString *)channelID;
+- (UIImage *)imageForEmoteCode:(NSString *)code;
+
+// Returns YES if the image has finished loading into memory
+- (BOOL)isEmoteReady:(NSString *)code;
+@end

--- a/TWThirdPartyEmoteManager.m
+++ b/TWThirdPartyEmoteManager.m
@@ -1,0 +1,153 @@
+#import "TWThirdPartyEmoteManager.h"
+
+@interface TWThirdPartyEmoteManager ()
+@property (nonatomic, strong) NSMutableDictionary<NSString *, NSURL *> *emoteURLs;
+@property (nonatomic, strong) NSMutableDictionary<NSString *, NSNumber *> *animatedFlags;
+@property (nonatomic, strong) NSMutableDictionary<NSString *, UIImage *> *emoteImages;
+@end
+
+@implementation TWThirdPartyEmoteManager
++ (instancetype)sharedManager {
+  static dispatch_once_t onceToken;
+  static TWThirdPartyEmoteManager *manager;
+  dispatch_once(&onceToken, ^{
+    manager = [TWThirdPartyEmoteManager new];
+  });
+  return manager;
+}
+- (instancetype)init {
+  if ((self = [super init])) {
+    _emoteURLs = [NSMutableDictionary dictionary];
+    _animatedFlags = [NSMutableDictionary dictionary];
+    _emoteImages = [NSMutableDictionary dictionary];
+  }
+  return self;
+}
+- (void)loadGlobalEmotes {
+  [self fetch7TVSet:@"https://7tv.io/v3/emote-sets/global"];
+  [self fetchBTTVGlobal];
+}
+- (void)loadChannelEmotesWithID:(NSString *)channelID {
+  if (!channelID) return;
+  NSString *sevenURL = [NSString stringWithFormat:@"https://7tv.io/v3/users/twitch/%@", channelID];
+  [self fetch7TVUser:sevenURL];
+  NSString *bttvURL = [NSString stringWithFormat:@"https://api.betterttv.net/3/cached/users/twitch/%@", channelID];
+  [self fetchBTTVChannel:bttvURL];
+}
+- (UIImage *)imageForEmoteCode:(NSString *)code {
+  UIImage *image = self.emoteImages[code];
+  if (!image) {
+    NSURL *url = self.emoteURLs[code];
+    if (!url) return nil;
+    NSData *data = [NSData dataWithContentsOfURL:url];
+    if (!data) return nil;
+    image = [UIImage imageWithData:data];
+    if (image) {
+      @synchronized(self) {
+        self.emoteImages[code] = image;
+      }
+    }
+  }
+  return image;
+}
+#pragma mark - Private
+- (void)fetch7TVSet:(NSString *)urlString {
+  NSURL *url = [NSURL URLWithString:urlString];
+  [[[NSURLSession sharedSession] dataTaskWithURL:url
+                               completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {
+    if (!data || error) return;
+    NSDictionary *json = [NSJSONSerialization JSONObjectWithData:data options:0 error:nil];
+    NSArray *emotes = json["emotes"];
+    for (NSDictionary *emote in emotes) {
+      NSString *code = emote[@"name"] ?: emote[@"data"][@"name"];
+      NSDictionary *dataDict = emote[@"data"] ?: @{};
+      BOOL animated = [dataDict[@"animated"] boolValue];
+      NSString *host = dataDict[@"host"][@"url"];
+      if (!code || !host) continue;
+      NSString *path = animated ? @"3x.gif" : @"3x.webp";
+      NSString *full = [NSString stringWithFormat:@"https:%@/%@", host, path];
+      NSURL *emoteURL = [NSURL URLWithString:full];
+      @synchronized(self) {
+        self.emoteURLs[code] = emoteURL;
+        self.animatedFlags[code] = @(animated);
+      }
+      [self cacheImageForCode:code url:emoteURL];
+    }
+  }] resume];
+}
+
+- (BOOL)isEmoteReady:(NSString *)code {
+  return self.emoteImages[code] != nil;
+}
+- (void)fetch7TVUser:(NSString *)urlString {
+  NSURL *url = [NSURL URLWithString:urlString];
+  [[[NSURLSession sharedSession] dataTaskWithURL:url
+                               completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {
+    if (!data || error) return;
+    NSDictionary *json = [NSJSONSerialization JSONObjectWithData:data options:0 error:nil];
+    NSString *setID = json[@"emote_set"][@"id"];
+    if (setID) {
+      NSString *setURL = [NSString stringWithFormat:@"https://7tv.io/v3/emote-sets/%@", setID];
+      [self fetch7TVSet:setURL];
+    }
+  }] resume];
+}
+- (void)fetchBTTVGlobal {
+  NSURL *url = [NSURL URLWithString:@"https://api.betterttv.net/3/cached/emotes/global"];
+  [[[NSURLSession sharedSession] dataTaskWithURL:url
+                               completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {
+    if (!data || error) return;
+    NSArray *json = [NSJSONSerialization JSONObjectWithData:data options:0 error:nil];
+    for (NSDictionary *emote in json) {
+      NSString *code = emote[@"code"];
+      NSString *idStr = emote[@"id"];
+      NSString *imageType = emote[@"imageType"];
+      if (!code || !idStr || !imageType) continue;
+      BOOL animated = [imageType.lowercaseString isEqualToString:@"gif"];
+      NSString *full = [NSString stringWithFormat:@"https://cdn.betterttv.net/emote/%@/3x.%@", idStr, imageType];
+      NSURL *emoteURL = [NSURL URLWithString:full];
+      @synchronized(self) {
+        self.emoteURLs[code] = emoteURL;
+        self.animatedFlags[code] = @(animated);
+      }
+      [self cacheImageForCode:code url:emoteURL];
+    }
+  }] resume];
+}
+- (void)fetchBTTVChannel:(NSString *)urlString {
+  NSURL *url = [NSURL URLWithString:urlString];
+  [[[NSURLSession sharedSession] dataTaskWithURL:url
+                               completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {
+    if (!data || error) return;
+    NSDictionary *json = [NSJSONSerialization JSONObjectWithData:data options:0 error:nil];
+    NSArray *emotes = json[@"shared"] ?: @[];
+    emotes = [emotes arrayByAddingObjectsFromArray:(json[@"channel"] ?: @[])];
+    for (NSDictionary *emote in emotes) {
+      NSString *code = emote[@"code"];
+      NSString *idStr = emote[@"id"];
+      NSString *imageType = emote[@"imageType"];
+      if (!code || !idStr || !imageType) continue;
+      BOOL animated = [imageType.lowercaseString isEqualToString:@"gif"];
+      NSString *full = [NSString stringWithFormat:@"https://cdn.betterttv.net/emote/%@/3x.%@", idStr, imageType];
+      NSURL *emoteURL = [NSURL URLWithString:full];
+      @synchronized(self) {
+        self.emoteURLs[code] = emoteURL;
+        self.animatedFlags[code] = @(animated);
+      }
+      [self cacheImageForCode:code url:emoteURL];
+    }
+  }] resume];
+}
+
+- (void)cacheImageForCode:(NSString *)code url:(NSURL *)url {
+  [[[NSURLSession sharedSession] dataTaskWithURL:url
+                               completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {
+    if (!data || error) return;
+    UIImage *img = [UIImage imageWithData:data];
+    if (!img) return;
+    @synchronized(self) {
+      self.emoteImages[code] = img;
+    }
+  }] resume];
+}
+@end

--- a/Tweak.x
+++ b/Tweak.x
@@ -1,5 +1,6 @@
 #import <dlfcn.h>
 #import "Tweak.h"
+#import "TWThirdPartyEmoteManager.h"
 
 NSBundle *tweakBundle;
 NSUserDefaults *tweakDefaults;
@@ -236,4 +237,5 @@ static void *hook_swift_unknownObjectWeakLoadStrong(void *ref) {
   if (![tweakDefaults objectForKey:@"TWAdBlockCustomProxyEnabled"])
     [tweakDefaults setBool:NO forKey:@"TWAdBlockCustomProxyEnabled"];
   assetResourceLoaderDelegate = [[TWAdBlockAssetResourceLoaderDelegate alloc] init];
+  [[TWThirdPartyEmoteManager sharedManager] loadGlobalEmotes];
 }


### PR DESCRIPTION
## Summary
- introduce `TWThirdPartyEmoteManager` for loading third‑party emotes
- import and initialise this manager in `Tweak.x`
- improve cache by storing downloaded images in memory

## Testing
- `make` *(fails: `/tweak.mk: No such file or directory`)*
- `curl` 7tv and BetterTTV API endpoints

------
https://chatgpt.com/codex/tasks/task_e_683fb712f4f88328a99340be0652c16c